### PR TITLE
🚧 Fix iOS 18 crash

### DIFF
--- a/Sources/Logging/DiagnosticsLogger.swift
+++ b/Sources/Logging/DiagnosticsLogger.swift
@@ -211,19 +211,14 @@ extension DiagnosticsLogger {
 
         guard
             var data = try? Data(contentsOf: self.logFileLocation, options: .mappedIfSafe),
-            !data.isEmpty,
-            let newline = "\n".data(using: .utf8) else {
-                return assertionFailure("Trimming the current log file failed")
+            !data.isEmpty else {
+                        return assertionFailure("Trimming the current log file failed")
         }
 
-        var position: Int = 0
-        while (logSize - Int64(position)) > (maximumSize - trimSize) {
-            guard let range = data.firstRange(of: newline, in: position ..< data.count) else { break }
-            position = range.startIndex.advanced(by: 1)
-        }
+        let trimmer = LogsTrimmer(numberOfLinesToTrim: 10)
+        trimmer.trim(data: &data)
 
-        logSize -= Int64(position)
-        data.removeSubrange(0 ..< position)
+        logSize = Int64(data.count)
 
         guard (try? data.write(to: logFileLocation, options: .atomic)) != nil else {
             return assertionFailure("Could not write trimmed log to target file location: \(logFileLocation)")

--- a/Sources/Logging/LogsTrimmer.swift
+++ b/Sources/Logging/LogsTrimmer.swift
@@ -1,0 +1,58 @@
+//
+//  LogsTrimmer.swift
+//
+//
+//  Created by Sabesh Bharathi on 13/06/24.
+//
+
+import Foundation
+
+//
+//  LogsTrimmer.swift
+//
+//
+//  Created by Antoine van der Lee on 01/03/2024.
+//
+
+import Foundation
+
+struct LogsTrimmer {
+    let numberOfLinesToTrim: Int
+
+    func trim(data: inout Data) {
+        guard let logs = String(data: data, encoding: .utf8) else {
+            return
+        }
+
+        // Define the regular expression pattern
+        let pattern = "<p class=\"system\"><span class=\"log-date\">(.*?)</span></p>"
+
+        // Create a regular expression object
+        guard let regex = try? NSRegularExpression(pattern: pattern) else {
+            return
+        }
+
+        // Find all matches in the input string
+        let matches = regex
+            .matches(
+                in: logs,
+                range: NSRange(location: 0, length: logs.utf16.count)
+            )
+            .suffix(numberOfLinesToTrim)
+
+        guard let firstMatch = matches.first, let lastMatch = matches.last else {
+            return
+        }
+
+        let range = NSRange(
+            location: firstMatch.range.location,
+            length: lastMatch.range.upperBound - firstMatch.range.location
+        )
+        guard let range = Range(range, in: logs) else {
+            return
+        }
+
+        let trimmedLogs = logs.replacingCharacters(in: range, with: "")
+        data = Data(trimmedLogs.utf8)
+    }
+}


### PR DESCRIPTION
### Context
Sequence of events in order:
1. WeTransfer added a logs trimmer to trim logs by lines rather than by bytes.
2. We pulled those changes to be consumed in our fork.
3. This started affecting a few users where the logs trimmed their new data rather than old data - so all affected users had logs from a certain date (I think April 25th or something) and older. Newer logs were not printed.
4. So we reverted this change. Now everything works well in production / App store.
5. But on iOS 18 beta - running the app crashes as the logger is not able to trim by bytes.
6. This does not fix the core issue itself, rather revert to state to point number 2^ so local builds can built without friction. Need to spend time to find a more robust solution but iOS 18 is still months away and could change drastically so not very important!