### PR TITLE
🔉 Clean up log time

### DIFF
--- a/Sources/Logging/Loggable.swift
+++ b/Sources/Logging/Loggable.swift
@@ -32,10 +32,18 @@ extension Loggable {
         }
     }
 
+    var dateFormatter: DateFormatter {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd hh:mm:ss a"
+        formatter.locale = Locale.current
+        formatter.timeZone = TimeZone.current
+        return formatter
+    }
+
     private var logMessage: String {
         var messages: [String] = []
         if let date {
-            let date = DateFormatter.current.string(from: date)
+            let date = dateFormatter.string(from: Date())
             messages.append("<span class=\"log-date\">\(date)</span>")
         }
         if let prefix {
@@ -116,7 +124,7 @@ struct SystemLog: Loggable {
     let cssClass: LoggableCSSClass? = .system
 
     init(line: String) {
-        message = "SYSTEM: \(line)"
+        message = line
     }
 }
 


### PR DESCRIPTION
Changes:
- Remove "SYSTEM" from every log message
- Format time to use current locale + show AM/PM indicator

<img width="1733" alt="Screenshot 2024-08-14 at 3 46 02 PM" src="https://github.com/user-attachments/assets/69d3fbd7-0206-4dc0-b75e-1e57aa1613d8">

